### PR TITLE
com.utilities.audio 1.1.0

### DIFF
--- a/Utilities.Audio/Packages/com.utilities.audio/Runtime/AudioClipExtensions.cs
+++ b/Utilities.Audio/Packages/com.utilities.audio/Runtime/AudioClipExtensions.cs
@@ -7,13 +7,13 @@ namespace Utilities.Audio
     public static class AudioClipExtensions
     {
         /// <summary>
-        /// Encodes the <see cref="AudioClip"/> to PCM.<br/>
+        /// Encodes the <see cref="AudioClip"/> to PCM.
         /// </summary>
         /// <param name="audioClip"><see cref="AudioClip"/>.</param>
         /// <param name="size">Size of PCM sample data.</param>
         /// <param name="trim">Optional, trim the silence from the data.</param>
         /// <returns>Byte array PCM data.</returns>
-        public static byte[] EncodeToPCM(this AudioClip audioClip, PCMFormatSize size = PCMFormatSize.EightBit, bool trim = false)
+        public static byte[] EncodeToPCM(this AudioClip audioClip, PCMFormatSize size = PCMFormatSize.SixteenBit, bool trim = false)
         {
             var samples = new float[audioClip.samples * audioClip.channels];
             audioClip.GetData(samples, 0);
@@ -21,12 +21,12 @@ namespace Utilities.Audio
         }
 
         /// <summary>
-        /// Decodes the raw PCM byte data and sets it to the <see cref="AudioClip"/>.<br/>
+        /// Decodes the raw PCM byte data and sets it to the <see cref="AudioClip"/>.
         /// </summary>
         /// <param name="audioClip"><see cref="AudioClip"/>.</param>
         /// <param name="pcmData">PCM data to decode.</param>
         /// <param name="size">Size of PCM sample data.</param>
-        public static void DecodeFromPCM(this AudioClip audioClip, byte[] pcmData, PCMFormatSize size = PCMFormatSize.EightBit)
+        public static void DecodeFromPCM(this AudioClip audioClip, byte[] pcmData, PCMFormatSize size = PCMFormatSize.SixteenBit)
         {
             var samples = PCMEncoder.Decode(pcmData, size);
             // Set the decoded audio data directly into the existing AudioClip

--- a/Utilities.Audio/Packages/com.utilities.audio/Runtime/PCMEncoder.cs
+++ b/Utilities.Audio/Packages/com.utilities.audio/Runtime/PCMEncoder.cs
@@ -14,7 +14,7 @@ namespace Utilities.Audio
         /// <param name="trim">Optional, trim the silence from the data.</param>
         /// <param name="silenceThreshold">Optional, silence threshold to use for trimming operations.</param>
         /// <returns>Byte array PCM data.</returns>
-        public static byte[] Encode(float[] samples, PCMFormatSize size = PCMFormatSize.EightBit, bool trim = false, float silenceThreshold = 0.001f)
+        public static byte[] Encode(float[] samples, PCMFormatSize size = PCMFormatSize.SixteenBit, bool trim = false, float silenceThreshold = 0.001f)
         {
             var sampleCount = samples.Length;
             var start = 0;
@@ -115,7 +115,7 @@ namespace Utilities.Audio
         /// </summary>
         /// <param name="pcmData">PCM data to decode.</param>
         /// <param name="size">Size of PCM sample data.</param>
-        public static float[] Decode(byte[] pcmData, PCMFormatSize size = PCMFormatSize.EightBit)
+        public static float[] Decode(byte[] pcmData, PCMFormatSize size = PCMFormatSize.SixteenBit)
         {
             if (pcmData.Length % (int)size != 0)
             {

--- a/Utilities.Audio/Packages/com.utilities.audio/Runtime/RecordingManager.cs
+++ b/Utilities.Audio/Packages/com.utilities.audio/Runtime/RecordingManager.cs
@@ -1,6 +1,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine;
@@ -10,6 +11,8 @@ namespace Utilities.Audio
 {
     public static class RecordingManager
     {
+        private static readonly ConcurrentDictionary<Type, IEncoder> EncoderCache = new ConcurrentDictionary<Type, IEncoder>();
+
         private static int maxRecordingLength = 300;
 
         private static readonly object recordingLock = new object();
@@ -43,7 +46,7 @@ namespace Utilities.Audio
             }
         }
 
-        public static int Frequency { get; set; } = 48000;
+        public static int Frequency { get; set; } = 44100;
 
         private static bool isRecording;
 
@@ -194,16 +197,35 @@ namespace Utilities.Audio
                 return null;
             }
 
+            Microphone.GetDeviceCaps(DefaultRecordingDevice, out var minFreq, out var maxFreq);
+
             if (EnableDebug)
             {
-                Microphone.GetDeviceCaps(DefaultRecordingDevice, out var minFreq, out var maxFreq);
                 var deviceName = string.IsNullOrWhiteSpace(DefaultRecordingDevice)
                     ? string.Join(", ", Microphone.devices)
                     : DefaultRecordingDevice;
                 Debug.Log($"[{nameof(RecordingManager)}] Recording device(s): {deviceName} | minFreq: {minFreq} | maxFreq {maxFreq}");
             }
 
-            var clip = Microphone.Start(DefaultRecordingDevice, false, MaxRecordingLength, Frequency);
+            var sampleRate = Frequency;
+
+            if (sampleRate <= minFreq)
+            {
+                sampleRate = minFreq;
+            }
+
+            if (sampleRate >= maxFreq)
+            {
+                sampleRate = maxFreq;
+            }
+
+            if (EnableDebug && sampleRate != Frequency)
+            {
+                Debug.LogWarning($"[{nameof(RecordingManager)}] Invalid Frequency {Frequency}. Using {sampleRate}");
+            }
+
+            // create dummy clip for recording purposes with a 10 second buffer.
+            var clip = Microphone.Start(DefaultRecordingDevice, loop: true, lengthSec: 10, sampleRate);
 
             if (clip == null)
             {
@@ -235,7 +257,12 @@ namespace Utilities.Audio
 
             try
             {
-                var encoder = Activator.CreateInstance<T>();
+                if (!EncoderCache.TryGetValue(typeof(T), out var encoder))
+                {
+                    encoder = Activator.CreateInstance<T>();
+                    EncoderCache.TryAdd(typeof(T), encoder);
+                }
+
                 return await encoder.StreamSaveToDiskAsync(clip, saveDirectory, cancellationTokenSource.Token, OnClipRecorded).ConfigureAwait(false);
             }
             catch (Exception e)

--- a/Utilities.Audio/Packages/com.utilities.audio/Tests/TestFixture_01_PCM_Encoding.cs
+++ b/Utilities.Audio/Packages/com.utilities.audio/Tests/TestFixture_01_PCM_Encoding.cs
@@ -44,7 +44,7 @@ namespace Utilities.Audio.Tests
             var encodedBytes = PCMEncoder.Encode(testSamples, PCMFormatSize.EightBit);
             var decodedSamples = PCMEncoder.Decode(encodedBytes, PCMFormatSize.EightBit);
 
-            File.WriteAllBytes("test-samples/8bit-wav.pcm", encodedBytes);
+            File.WriteAllBytes("test-samples/8bit-sine.pcm", encodedBytes);
 
             // Assert at the end of the unit test
             Assert.AreEqual(TestSampleRate, decodedSamples.Length);
@@ -67,7 +67,7 @@ namespace Utilities.Audio.Tests
             var encodedBytes = PCMEncoder.Encode(testSamples, PCMFormatSize.EightBit, true);
             var decodedSamples = PCMEncoder.Decode(encodedBytes, PCMFormatSize.EightBit);
 
-            File.WriteAllBytes("test-samples/8bit-wav-trimmed.pcm", encodedBytes);
+            File.WriteAllBytes("test-samples/8bit-sine-trimmed.pcm", encodedBytes);
 
             // The decoded samples should be only the non-silent portion of the original samples.
             Assert.AreEqual(TestSampleRate, decodedSamples.Length, "Decoded samples length should match the non-silent sample length after trimming.");
@@ -87,7 +87,7 @@ namespace Utilities.Audio.Tests
             var encodedBytes = PCMEncoder.Encode(testSamples, PCMFormatSize.SixteenBit);
             var decodedSamples = PCMEncoder.Decode(encodedBytes, PCMFormatSize.SixteenBit);
 
-            File.WriteAllBytes("test-samples/16bit-wav.pcm", encodedBytes);
+            File.WriteAllBytes("test-samples/16bit-sine.pcm", encodedBytes);
 
             Assert.AreEqual(TestSampleRate, decodedSamples.Length, "Decoded samples length should match the original sample length.");
 
@@ -110,7 +110,7 @@ namespace Utilities.Audio.Tests
             var encodedBytes = PCMEncoder.Encode(testSamples, PCMFormatSize.SixteenBit, true);
             var decodedSamples = PCMEncoder.Decode(encodedBytes, PCMFormatSize.SixteenBit);
 
-            File.WriteAllBytes("test-samples/16bit-wav-trimmed.pcm", encodedBytes);
+            File.WriteAllBytes("test-samples/16bit-sine-trimmed.pcm", encodedBytes);
 
             Assert.AreEqual(TestSampleRate, decodedSamples.Length, "Decoded samples length should match the non-silent sample length after trimming.");
 
@@ -129,7 +129,7 @@ namespace Utilities.Audio.Tests
             var encodedBytes = PCMEncoder.Encode(testSamples, PCMFormatSize.TwentyFourBit);
             var decodedSamples = PCMEncoder.Decode(encodedBytes, PCMFormatSize.TwentyFourBit);
 
-            File.WriteAllBytes("test-samples/24bit-wav.pcm", encodedBytes);
+            File.WriteAllBytes("test-samples/24bit-sine.pcm", encodedBytes);
 
             Assert.AreEqual(TestSampleRate, decodedSamples.Length, "Decoded samples length should match the original sample length.");
 
@@ -152,7 +152,7 @@ namespace Utilities.Audio.Tests
             var encodedBytes = PCMEncoder.Encode(testSamples, PCMFormatSize.TwentyFourBit, true);
             var decodedSamples = PCMEncoder.Decode(encodedBytes, PCMFormatSize.TwentyFourBit);
 
-            File.WriteAllBytes("test-samples/24bit-wav-trimmed.pcm", encodedBytes);
+            File.WriteAllBytes("test-samples/24bit-sine-trimmed.pcm", encodedBytes);
 
             Assert.AreEqual(TestSampleRate, decodedSamples.Length, "Decoded samples length should match the non-silent sample length after trimming.");
 
@@ -171,7 +171,7 @@ namespace Utilities.Audio.Tests
             var encodedBytes = PCMEncoder.Encode(testSamples, PCMFormatSize.ThirtyTwoBit);
             var decodedSamples = PCMEncoder.Decode(encodedBytes, PCMFormatSize.ThirtyTwoBit);
 
-            File.WriteAllBytes("test-samples/32bit-wav.pcm", encodedBytes);
+            File.WriteAllBytes("test-samples/32bit-sine.pcm", encodedBytes);
 
             Assert.AreEqual(TestSampleRate, decodedSamples.Length, "Decoded samples length should match the original sample length.");
 
@@ -194,7 +194,7 @@ namespace Utilities.Audio.Tests
             var encodedBytes = PCMEncoder.Encode(testSamples, PCMFormatSize.ThirtyTwoBit, true);
             var decodedSamples = PCMEncoder.Decode(encodedBytes, PCMFormatSize.ThirtyTwoBit);
 
-            File.WriteAllBytes("test-samples/32bit-wav-trimmed.pcm", encodedBytes);
+            File.WriteAllBytes("test-samples/32bit-sine-trimmed.pcm", encodedBytes);
 
             Assert.AreEqual(TestSampleRate, decodedSamples.Length, "Decoded samples length should match the non-silent sample length after trimming.");
 

--- a/Utilities.Audio/Packages/com.utilities.audio/package.json
+++ b/Utilities.Audio/Packages/com.utilities.audio/package.json
@@ -3,7 +3,7 @@
   "displayName": "Utilities.Audio",
   "description": "A simple package for audio extensions and utilities.",
   "keywords": [],
-  "version": "1.0.14",
+  "version": "1.1.0",
   "unity": "2021.3",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.audio#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.audio/releases",


### PR DESCRIPTION
- Breaking Change: base clip is now a 10 second loop
  - Reduces overhead for larger recording lengths
  - Theoretically removes the max recording length limitation, but still capped at 300 seconds
- Cache encoder instance
- Set Frequency to either min or max frequency that the microphone can handle
- Updated default bit depth from 8-bit to 16-bit