### PR TITLE
com.utilities.audio 2.0.2

### DIFF
--- a/Utilities.Audio/Packages/com.utilities.audio/Runtime/ClipData.cs
+++ b/Utilities.Audio/Packages/com.utilities.audio/Runtime/ClipData.cs
@@ -14,7 +14,6 @@ namespace Utilities.Audio
             Channels = clip.channels;
             BufferSize = clip.samples;
             SampleRate = clip.frequency;
-            MaxSamples = RecordingManager.MaxRecordingLength * SampleRate;
         }
 
         public AudioClip Clip { get; }
@@ -29,6 +28,6 @@ namespace Utilities.Audio
 
         public int SampleRate { get; }
 
-        public int MaxSamples { get; }
+        public int? MaxSamples { get; internal set; }
     }
 }

--- a/Utilities.Audio/Packages/com.utilities.audio/Runtime/RecordingManager.cs
+++ b/Utilities.Audio/Packages/com.utilities.audio/Runtime/RecordingManager.cs
@@ -265,7 +265,9 @@ namespace Utilities.Audio
                     encoderCache.TryAdd(typeof(TEncoder), encoder);
                 }
 
-                return await encoder.StreamSaveToDiskAsync(InitializeRecording(clip), saveDirectory, OnClipRecorded, cancellationTokenSource.Token);
+                var clipData = InitializeRecording(clip);
+                clipData.MaxSamples = MaxRecordingLength * clip.frequency;
+                return await encoder.StreamSaveToDiskAsync(clipData, saveDirectory, OnClipRecorded, cancellationTokenSource.Token);
             }
             catch (Exception e)
             {

--- a/Utilities.Audio/Packages/com.utilities.audio/package.json
+++ b/Utilities.Audio/Packages/com.utilities.audio/package.json
@@ -3,7 +3,7 @@
   "displayName": "Utilities.Audio",
   "description": "A simple package for audio extensions and utilities.",
   "keywords": [],
-  "version": "2.0.1",
+  "version": "2.0.2",
   "unity": "2021.3",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.audio#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.audio/releases",


### PR DESCRIPTION
- fixed a missing reference exception when cancelling streaming audio only
- fixed a bug where streaming audio would stop when max samples are hit, but we don't have to stop since we're not saving the samples to AudioClip