### PR TITLE
com.utilities.audio 3.0.2

### DIFF
--- a/Utilities.Audio/Packages/com.utilities.audio/Runtime/AbstractRecordingBehaviour.cs
+++ b/Utilities.Audio/Packages/com.utilities.audio/Runtime/AbstractRecordingBehaviour.cs
@@ -178,6 +178,11 @@ namespace Utilities.Audio
                     }
                 }
 
+                if (debug)
+                {
+                    UnityEngine.Debug.Log($"recording sample rate: {recordingSampleRate}");
+                }
+
                 // Starts the recording process
                 var (path, newClip) = await RecordingManager.StartRecordingAsync<TEncoder>(
                     outputSampleRate: recordingSampleRate,

--- a/Utilities.Audio/Packages/com.utilities.audio/Runtime/AbstractStreamRecordingBehaviour.cs
+++ b/Utilities.Audio/Packages/com.utilities.audio/Runtime/AbstractStreamRecordingBehaviour.cs
@@ -116,7 +116,7 @@ namespace Utilities.Audio
                         }
 
                         RecordingManager.StartRecordingStream<PCMEncoder>(
-                            sampleCallback: (samples, count) => streamAudioSource.SampleCallbackAsync(samples, count, recordingSampleRate, AudioSettings.outputSampleRate),
+                            sampleCallback: (samples, count) => streamAudioSource.SampleCallback(samples, count, recordingSampleRate, AudioSettings.outputSampleRate),
                             outputSampleRate: recordingSampleRate,
                             cancellationToken: destroyCancellationToken);
                     }

--- a/Utilities.Audio/Packages/com.utilities.audio/Runtime/AbstractStreamRecordingBehaviour.cs
+++ b/Utilities.Audio/Packages/com.utilities.audio/Runtime/AbstractStreamRecordingBehaviour.cs
@@ -101,7 +101,7 @@ namespace Utilities.Audio
                             if (sampleRate == 0)
                             {
                                 Microphone.GetDeviceCaps(RecordingManager.DefaultRecordingDevice, out _, out var max);
-                                recordingSampleRate = max;
+                                recordingSampleRate = Mathf.Min(max, AudioSettings.outputSampleRate);
                             }
                             else
                             {
@@ -116,9 +116,9 @@ namespace Utilities.Audio
                         }
 
                         RecordingManager.StartRecordingStream<PCMEncoder>(
-                            (samples, count) => streamAudioSource.SampleCallback(samples, count),
-                            recordingSampleRate,
-                            destroyCancellationToken);
+                            sampleCallback: (samples, count) => streamAudioSource.SampleCallbackAsync(samples, count, recordingSampleRate, AudioSettings.outputSampleRate),
+                            outputSampleRate: recordingSampleRate,
+                            cancellationToken: destroyCancellationToken);
                     }
                 }
             }

--- a/Utilities.Audio/Packages/com.utilities.audio/Runtime/PCMEncoder.cs
+++ b/Utilities.Audio/Packages/com.utilities.audio/Runtime/PCMEncoder.cs
@@ -40,7 +40,7 @@ namespace Utilities.Audio
 
             try
             {
-                encode = Encode(native, size, trim, silenceThreshold, inputSampleRate, outputSampleRate);
+                encode = Encode(native, size, trim, silenceThreshold, inputSampleRate, outputSampleRate, Allocator.Persistent);
                 return encode.Value.ToArray();
             }
             finally
@@ -64,9 +64,13 @@ namespace Utilities.Audio
         [Preserve]
         public static NativeArray<byte> Encode(NativeArray<float> samples, PCMFormatSize size = PCMFormatSize.SixteenBit, bool trim = false, float silenceThreshold = 0.001f, int? inputSampleRate = null, int? outputSampleRate = null, Allocator allocator = Allocator.Temp)
         {
+            var disposeSamples = false;
+
             if (inputSampleRate.HasValue && outputSampleRate.HasValue)
             {
-                samples = Resample(samples, inputSampleRate.Value, outputSampleRate.Value);
+                var resample = Resample(samples, inputSampleRate.Value, outputSampleRate.Value, Allocator.Persistent);
+                samples = resample;
+                disposeSamples = true;
             }
             else if (inputSampleRate.HasValue || outputSampleRate.HasValue)
             {
@@ -106,7 +110,17 @@ namespace Utilities.Audio
                 }
             }
 
-            return Encode(samples, start, length, size, allocator);
+            try
+            {
+                return Encode(samples, start, length, size, allocator);
+            }
+            finally
+            {
+                if (disposeSamples)
+                {
+                    samples.Dispose();
+                }
+            }
         }
 
         [Preserve]
@@ -201,9 +215,8 @@ namespace Utilities.Audio
 
             try
             {
-                decode = Decode(native, size, inputSampleRate, outputSampleRate);
-                var array = decode.Value.ToArray();
-                return array;
+                decode = Decode(native, size, inputSampleRate, outputSampleRate, Allocator.Persistent);
+                return decode.Value.ToArray();
             }
             finally
             {
@@ -309,14 +322,13 @@ namespace Utilities.Audio
         {
             if (inputSampleRate == outputSampleRate) { return samples; }
 
-            var native = new NativeArray<float>(samples, Allocator.Persistent);
             NativeArray<float>? resample = null;
+            var native = new NativeArray<float>(samples, Allocator.Persistent);
 
             try
             {
-                resample = Resample(native, inputSampleRate, outputSampleRate);
-                var array = resample.Value.ToArray();
-                return array;
+                resample = Resample(native, inputSampleRate, outputSampleRate, Allocator.Persistent);
+                return resample.Value.ToArray();
             }
             finally
             {
@@ -354,7 +366,6 @@ namespace Utilities.Audio
                 buffer[i] = math.lerp(samples[floor], samples[ceil], index - floor);
             }
 
-            samples.Dispose();
             return buffer;
         }
 

--- a/Utilities.Audio/Packages/com.utilities.audio/Runtime/PCMEncoder.cs
+++ b/Utilities.Audio/Packages/com.utilities.audio/Runtime/PCMEncoder.cs
@@ -35,14 +35,17 @@ namespace Utilities.Audio
         /// <returns>Byte array PCM data.</returns>
         public static byte[] Encode(float[] samples, PCMFormatSize size = PCMFormatSize.SixteenBit, bool trim = false, float silenceThreshold = 0.001f, int? inputSampleRate = null, int? outputSampleRate = null)
         {
+            NativeArray<byte>? encode = null;
             var native = new NativeArray<float>(samples, Allocator.Persistent);
 
             try
             {
-                return Encode(native, size, trim, silenceThreshold, inputSampleRate, outputSampleRate).ToArray();
+                encode = Encode(native, size, trim, silenceThreshold, inputSampleRate, outputSampleRate);
+                return encode.Value.ToArray();
             }
             finally
             {
+                encode?.Dispose();
                 native.Dispose();
             }
         }
@@ -222,6 +225,11 @@ namespace Utilities.Audio
                 throw new Exception($"{nameof(pcmData)} length must be multiple of the specified {nameof(PCMFormatSize)}!");
             }
 
+            if (pcmData.Length == 0)
+            {
+                return new NativeArray<float>(0, allocator);
+            }
+
             var sampleCount = pcmData.Length / (int)size;
             var samples = new NativeArray<float>(sampleCount, allocator);
             var sampleIndex = 0;
@@ -338,6 +346,7 @@ namespace Utilities.Audio
                 buffer[i] = math.lerp(samples[floor], samples[ceil], index - floor);
             }
 
+            samples.Dispose();
             return buffer;
         }
 

--- a/Utilities.Audio/Packages/com.utilities.audio/Runtime/PCMEncoder.cs
+++ b/Utilities.Audio/Packages/com.utilities.audio/Runtime/PCMEncoder.cs
@@ -197,13 +197,17 @@ namespace Utilities.Audio
             }
 
             var native = new NativeArray<byte>(pcmData, Allocator.Persistent);
+            NativeArray<float>? decode = null;
 
             try
             {
-                return Decode(native, size, inputSampleRate, outputSampleRate).ToArray();
+                decode = Decode(native, size, inputSampleRate, outputSampleRate);
+                var array = decode.Value.ToArray();
+                return array;
             }
             finally
             {
+                decode?.Dispose();
                 native.Dispose();
             }
         }
@@ -306,13 +310,17 @@ namespace Utilities.Audio
             if (inputSampleRate == outputSampleRate) { return samples; }
 
             var native = new NativeArray<float>(samples, Allocator.Persistent);
+            NativeArray<float>? resample = null;
 
             try
             {
-                return Resample(native, inputSampleRate, outputSampleRate).ToArray();
+                resample = Resample(native, inputSampleRate, outputSampleRate);
+                var array = resample.Value.ToArray();
+                return array;
             }
             finally
             {
+                resample?.Dispose();
                 native.Dispose();
             }
         }

--- a/Utilities.Audio/Packages/com.utilities.audio/Runtime/PCMEncoder.cs
+++ b/Utilities.Audio/Packages/com.utilities.audio/Runtime/PCMEncoder.cs
@@ -69,8 +69,8 @@ namespace Utilities.Audio
             if (inputSampleRate.HasValue && outputSampleRate.HasValue)
             {
                 var resample = Resample(samples, inputSampleRate.Value, outputSampleRate.Value, Allocator.Persistent);
+                disposeSamples = samples != resample;
                 samples = resample;
-                disposeSamples = true;
             }
             else if (inputSampleRate.HasValue || outputSampleRate.HasValue)
             {

--- a/Utilities.Audio/Packages/com.utilities.audio/Samples~/PCMRecording/AudioReactiveBehaviour.cs
+++ b/Utilities.Audio/Packages/com.utilities.audio/Samples~/PCMRecording/AudioReactiveBehaviour.cs
@@ -22,7 +22,7 @@ namespace Utilities.Encoder.PCM.Samples.Recording
         private float targetScale = 1f;
 
         /// <summary>
-        /// Called automatically by Unity’s audio system on the audio thread
+        /// Called automatically by Unity's audio system on the audio thread
         /// </summary>
         /// <param name="data"></param>
         /// <param name="channels"></param>

--- a/Utilities.Audio/Packages/com.utilities.audio/Samples~/PCMRecording/MicrophonePCMRecroding.unity
+++ b/Utilities.Audio/Packages/com.utilities.audio/Samples~/PCMRecording/MicrophonePCMRecroding.unity
@@ -402,7 +402,6 @@ MonoBehaviour:
     m_Reference: {fileID: 0}
   debug: 1
   sampleRate: 0
-  recordingSampleRate: -1
 --- !u!82 &545589674
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Utilities.Audio/Packages/com.utilities.audio/Samples~/PCMRecording/MicrophonePCMRecrodingStreaming.unity
+++ b/Utilities.Audio/Packages/com.utilities.audio/Samples~/PCMRecording/MicrophonePCMRecrodingStreaming.unity
@@ -514,7 +514,7 @@ MonoBehaviour:
       m_Flags: 0
     m_Reference: {fileID: 0}
   debug: 1
-  sampleRate: 48000
+  sampleRate: 0
 --- !u!114 &545589677
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Utilities.Audio/Packages/com.utilities.audio/package.json
+++ b/Utilities.Audio/Packages/com.utilities.audio/package.json
@@ -3,7 +3,7 @@
   "displayName": "Utilities.Audio",
   "description": "A simple package for audio extensions and utilities.",
   "keywords": [],
-  "version": "3.0.1",
+  "version": "3.0.2",
   "unity": "2021.3",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.audio#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.audio/releases",
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "com.utilities.async": "3.0.2",
-    "com.utilities.extensions": "1.3.7",
+    "com.utilities.extensions": "1.3.8",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.collections": "1.2.4",
     "com.unity.modules.audio": "1.0.0",


### PR DESCRIPTION
- tweak AbstractStreamRecordingBehaviour to better match loopback recording
- Ensured all `NativeArray` allocations for PCM encoding, decoding, and resampling in `PCMEncoder.cs` are properly disposed to prevent memory leaks. This includes wrapping allocations in try/finally blocks and disposing of temporary arrays after use. 
- Updated `DecodeFromPCM` in `AudioClipExtensions.cs` to dispose of native arrays after setting audio data, further improving memory management.
- Added a check in `Decode` to handle empty PCM data arrays gracefully, returning an empty array instead of throwing
- Updated the streaming recording callback to pass both the recording and output sample rates, enabling more accurate processing
- updated com.utilities.extensions 1.3.8